### PR TITLE
Separate fellowship content

### DIFF
--- a/aa.html
+++ b/aa.html
@@ -1,0 +1,69 @@
+<!DOCTYPE doctype html>
+
+<html>
+	<head>
+		<meta charset="utf-8"/>
+		<meta content="ie=edge" http-equiv="x-ua-compatible"/>
+		<title>Greenbelt Step Club, Inc</title>
+		<meta content="" name="description"/>
+		<!-- Tell browser that the website is optimized for the phone -->
+		<meta content="width=device-width, initial-scale=1" name="viewport"/>
+		<!--Import materialize.css-->
+		<link href="css/materialize.min.css" rel="stylesheet" type="text/css"/>
+		<link href="css/custom.css" rel="stylesheet" type="text/css"/>
+		<!-- Material Icons -->
+		<link href="css/local-gstatic.css" rel="stylesheet"/>
+	</head>
+	<body class="white">
+		<nav class="navbar">
+			<div class="nav-wrapper green darken-3">
+				<a class="brand-logo center" href="#" id="navbar-title">Sunshine Sobriety Group</a>
+			</div>
+		</nav>
+		<main class="white">
+			<div class="center-text">
+				<h3 >Welcome!</h3>
+				<h5>This page is made by and for the 6:45 AM Sushine Sobriety Group of Alcoholics Anonymous</h5>
+				<h5>Find helpful resources below</h5>
+			</div>
+			
+			<div class="flex fdc center-text">
+				<a href="https://drive.google.com/file/d/1Xbo0TSDM-wIXedafhGILJW_2EL-dmebS/view?usp=sharing">
+					Joe and Charlie Big Book Study (zip file)
+				</a>
+				<a href="https://drive.google.com/file/d/1LoWTko56SBLyxx_rnUS-5I_01FwiYX9n/view?usp=sharing">
+					4th Step Workshop Handouts
+				</a>
+			</div>
+		</main>
+		<footer class="page-footer green darken-3">
+			<div class="container">
+				<div class="row">
+					<div class="col l6 s12">
+						<h5 class="white-text"></h5>
+						<p class="grey-text text-lighten-4"></p>
+					</div>
+					<div class="col l4 offset-l2 s12">
+						<ul>
+							<li><a class="white-text" href="index.html"></a></li>
+							<li><a class="white-text" href="index.html"></a></li>
+							<li><a class="white-text" href="index.html"></a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</footer>
+		<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+		<script src="js/materialize.min.js" type="text/javascript"></script>
+
+<script type="text/javascript">
+
+//     https://learn.jquery.com/using-jquery-core/document-ready/
+$(document).ready(function(){
+	//      https://materializecss.com/dropdown.html
+	M.AutoInit();
+	$('.sidenav').sidenav();
+});
+		</script>
+	</body>
+</html>

--- a/about.html
+++ b/about.html
@@ -20,7 +20,7 @@
 				<a class="brand-logo center" href="#" id="navbar-title">Greenbelt Step Club</a>
 				<ul class="right hide-on-med-and-down" id="nav-mobile">
 					<li class=""><a href="index.html">Meetings</a></li>
-					<li class="active"><a href="about.html">About</a></li>
+					<li class=""><a href="newcomers.html">Newcomers</a></li>
 					<li class=""><a class="dropdown-trigger" data-target="dropdown-more" href="#">More<i class="material-icons right">arrow_drop_down</i></a></li>
 				</ul>
 				<!-- this makes the navbar slide out for the phone -->
@@ -28,17 +28,17 @@
 			</div>
 		</nav>
 		<ul class="dropdown-content" id="dropdown-more">
-			<li class=""><a href="contact.html">Contact Us</a></li>
+			<li class=""><a href="resources.html">Resources</a></li>
 			<li class=""><a href="donate.html">Donate</a></li>
-			<li class=""><a href="links.html">Link</a></li>
+			<li class="active"><a href="about.html">About</a></li>
 		</ul>
 		<!-- this will appear on the phone navbar -->
 		<ul class="sidenav" id="slide-out">
 			<li class=""><a href="index.html">Meetings</a></li>
-			<li class="active"><a href="about.html">About</a></li>
-			<li class=""><a href="contact.html">Contact Us</a></li>
+			<li class=""><a href="newcomers.html">Newcomers</a></li>
+			<li class=""><a href="resources.html">Resources</a></li>
 			<li class=""><a href="donate.html">Donate</a></li>
-			<li class=""><a href="links.html">Link</a></li>
+			<li class="active"><a href="about.html">About</a></li>
 		</ul>
 		<main class="white">
 			<h3 class="center-text">Our Purpose</h3>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 				<a class="brand-logo center" href="#" id="navbar-title">Greenbelt Step Club</a>
 				<ul class="right hide-on-med-and-down" id="nav-mobile">
 					<li class="active"><a href="index.html">Meetings</a></li>
-					<li class=""><a href="about.html">About</a></li>
+					<li class=""><a href="newcomers.html">Newcomers</a></li>
 					<li class=""><a class="dropdown-trigger" data-target="dropdown-more" href="#">More<i class="material-icons right">arrow_drop_down</i></a></li>
 				</ul>
 				<!-- this makes the navbar slide out for the phone -->
@@ -28,17 +28,17 @@
 			</div>
 		</nav>
 		<ul class="dropdown-content" id="dropdown-more">
-			<li class=""><a href="contact.html">Contact Us</a></li>
+			<li class=""><a href="resources.html">Resources</a></li>
 			<li class=""><a href="donate.html">Donate</a></li>
-			<li class=""><a href="links.html">Link</a></li>
+			<li class=""><a href="about.html">About</a></li>
 		</ul>
 		<!-- this will appear on the phone navbar -->
 		<ul class="sidenav" id="slide-out">
 			<li class="active"><a href="index.html">Meetings</a></li>
-			<li class=""><a href="about.html">About</a></li>
-			<li class=""><a href="contact.html">Contact Us</a></li>
+			<li class=""><a href="newcomers.html">Newcomers</a></li>
+			<li class=""><a href="resources.html">Resources</a></li>
 			<li class=""><a href="donate.html">Donate</a></li>
-			<li class=""><a href="links.html">Link</a></li>
+			<li class=""><a href="about.html">About</a></li>
 		</ul>
 		<div class="modal" id="legend-modal">
 			<div class="modal-content">

--- a/navigation-generator.py
+++ b/navigation-generator.py
@@ -6,14 +6,14 @@ import format
 # the main bar has 3 items as of now, the third one being "More", defined in drop_down
 main_bar = { \
 	'index.html': 'Meetings', \
-	'about.html': 'About', \
+	'newcomers.html': 'Newcomers', \
 	}
 
 # contents of "More"
 drop_down = { \
-	'contact.html': 'Contact Us', \
+	'resources.html': 'Resources', \
 	'donate.html' : 'Donate', \
-	'links.html' : 'Link', \
+	'about.html' : 'About', \
 	}
 
 # everything is listed in the sidenav, used for mobile browsers 

--- a/newcomers.html
+++ b/newcomers.html
@@ -20,7 +20,7 @@
 				<a class="brand-logo center" href="#" id="navbar-title">Greenbelt Step Club</a>
 				<ul class="right hide-on-med-and-down" id="nav-mobile">
 					<li class=""><a href="index.html">Meetings</a></li>
-					<li class=""><a href="newcomers.html">Newcomers</a></li>
+					<li class="active"><a href="newcomers.html">Newcomers</a></li>
 					<li class=""><a class="dropdown-trigger" data-target="dropdown-more" href="#">More<i class="material-icons right">arrow_drop_down</i></a></li>
 				</ul>
 				<!-- this makes the navbar slide out for the phone -->
@@ -29,86 +29,23 @@
 		</nav>
 		<ul class="dropdown-content" id="dropdown-more">
 			<li class=""><a href="resources.html">Resources</a></li>
-			<li class="active"><a href="donate.html">Donate</a></li>
+			<li class=""><a href="donate.html">Donate</a></li>
 			<li class=""><a href="about.html">About</a></li>
 		</ul>
 		<!-- this will appear on the phone navbar -->
 		<ul class="sidenav" id="slide-out">
 			<li class=""><a href="index.html">Meetings</a></li>
-			<li class=""><a href="newcomers.html">Newcomers</a></li>
+			<li class="active"><a href="newcomers.html">Newcomers</a></li>
 			<li class=""><a href="resources.html">Resources</a></li>
-			<li class="active"><a href="donate.html">Donate</a></li>
+			<li class=""><a href="donate.html">Donate</a></li>
 			<li class=""><a href="about.html">About</a></li>
 		</ul>
 		<main class="white">
-			<div class="flex fdc aic">
-				<h4 class="center-text">Every 12 step group ought to be fully self-supporting, declining outside contributions.
-				</h4>
-				<div class="">
-					<ul class="browser-default">
-						<li>
-							Greenblet Step Club - PayPal
-							<ul class="browser-default">
-								<li>
-									<a href="https://www.paypal.com/paypalme/gbstepclub">paypal.me/gbstepclub</a>
-								</li>
-								<li>
-									indicate fellowship/group
-								</li>
-							</ul>
-						</li>
-						<li>
-							Greenblet Step Club - Venmo
-							<ul class="browser-default">
-								<li>
-									gbstepclub@gmail.com
-								</li>
-								<li>
-									indicate fellowship/group
-								</li>
-							</ul>
-						</li>
-						<li>
-							Greenblet Step Club - Personal Check
-							<ul class="browser-default">
-								<li>
-									PO Box 1084, Greenbelt MD 20768-1084
-								</li>
-								<li>
-									indicate fellowship/group
-								</li>
-							</ul>
-						</li>
-					</ul>
-				</div>
-				<div class="flex fdc aic jcc center-text" id="contributions-list">
-					<h5>Contribute to your fellowship's service structure</h5>
-					<a href="https://aa-dc.org/waia-online-contribution/individual-contribution">
-						Washington Area Intergroup (AA)
-					</a>
-					<a href="https://contribution.aa.org/sca-dev-2020-1/checkout.ssp?is=checkout#login-register">
-						Alcoholics Anonymous General Service Office
-					</a>
-					<a href="https://www.dc-aca.org/7th-tradition">
-						Adult Children of Alcoholics National Capital Area Intergroup
-					</a>
-					<a href="https://al-anon.org/contributions/">
-						Al-Anon Family Group Headquarters
-					</a>
-					<a href="https://www.cdaweb.org/outreach">
-						CDA General Service
-					</a>
-					<a href="http://www.draonline.org/contributions.html">
-						DRA World Services
-					</a>
-					<a href="https://www.na.org/?ID=contribute-now">
-						NA World Services
-					</a>
-					<a href="https://saa-recovery.org/contribute/general-donations/">
-						SAA ISO
-					</a>
-				</div>
-			</div>
+			<h3 class="center-text">For the Newcomer</h3>
+			<h4 class="center-text">Which 12-step fellowship is right for you?</h4>
+			<div class="my-text-section">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+			<h4 class="center-text">Find other Meetings</h4>
+			<div class="my-text-section">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
 		</main>
 		<footer class="page-footer green darken-3">
 			<div class="container">
@@ -131,8 +68,9 @@
 		<script src="js/materialize.min.js" type="text/javascript"></script>
 
 <script type="text/javascript">
+
 //     https://learn.jquery.com/using-jquery-core/document-ready/
-$(document).ready(function () {
+$(document).ready(function(){
 	
 	//      https://materializecss.com/dropdown.html
 	M.AutoInit();

--- a/resources.html
+++ b/resources.html
@@ -46,7 +46,6 @@
 				<h5>The 12 step groups from the Greenbelt Step Club may optionally have their own web page listed below</h5>
 				<a href="aa.html">AA</a>
 			</div>
-			
 		</main>
 		<footer class="page-footer green darken-3">
 			<div class="container">

--- a/resources.html
+++ b/resources.html
@@ -28,87 +28,25 @@
 			</div>
 		</nav>
 		<ul class="dropdown-content" id="dropdown-more">
-			<li class=""><a href="resources.html">Resources</a></li>
-			<li class="active"><a href="donate.html">Donate</a></li>
+			<li class="active"><a href="resources.html">Resources</a></li>
+			<li class=""><a href="donate.html">Donate</a></li>
 			<li class=""><a href="about.html">About</a></li>
 		</ul>
 		<!-- this will appear on the phone navbar -->
 		<ul class="sidenav" id="slide-out">
 			<li class=""><a href="index.html">Meetings</a></li>
 			<li class=""><a href="newcomers.html">Newcomers</a></li>
-			<li class=""><a href="resources.html">Resources</a></li>
-			<li class="active"><a href="donate.html">Donate</a></li>
+			<li class="active"><a href="resources.html">Resources</a></li>
+			<li class=""><a href="donate.html">Donate</a></li>
 			<li class=""><a href="about.html">About</a></li>
 		</ul>
 		<main class="white">
-			<div class="flex fdc aic">
-				<h4 class="center-text">Every 12 step group ought to be fully self-supporting, declining outside contributions.
-				</h4>
-				<div class="">
-					<ul class="browser-default">
-						<li>
-							Greenblet Step Club - PayPal
-							<ul class="browser-default">
-								<li>
-									<a href="https://www.paypal.com/paypalme/gbstepclub">paypal.me/gbstepclub</a>
-								</li>
-								<li>
-									indicate fellowship/group
-								</li>
-							</ul>
-						</li>
-						<li>
-							Greenblet Step Club - Venmo
-							<ul class="browser-default">
-								<li>
-									gbstepclub@gmail.com
-								</li>
-								<li>
-									indicate fellowship/group
-								</li>
-							</ul>
-						</li>
-						<li>
-							Greenblet Step Club - Personal Check
-							<ul class="browser-default">
-								<li>
-									PO Box 1084, Greenbelt MD 20768-1084
-								</li>
-								<li>
-									indicate fellowship/group
-								</li>
-							</ul>
-						</li>
-					</ul>
-				</div>
-				<div class="flex fdc aic jcc center-text" id="contributions-list">
-					<h5>Contribute to your fellowship's service structure</h5>
-					<a href="https://aa-dc.org/waia-online-contribution/individual-contribution">
-						Washington Area Intergroup (AA)
-					</a>
-					<a href="https://contribution.aa.org/sca-dev-2020-1/checkout.ssp?is=checkout#login-register">
-						Alcoholics Anonymous General Service Office
-					</a>
-					<a href="https://www.dc-aca.org/7th-tradition">
-						Adult Children of Alcoholics National Capital Area Intergroup
-					</a>
-					<a href="https://al-anon.org/contributions/">
-						Al-Anon Family Group Headquarters
-					</a>
-					<a href="https://www.cdaweb.org/outreach">
-						CDA General Service
-					</a>
-					<a href="http://www.draonline.org/contributions.html">
-						DRA World Services
-					</a>
-					<a href="https://www.na.org/?ID=contribute-now">
-						NA World Services
-					</a>
-					<a href="https://saa-recovery.org/contribute/general-donations/">
-						SAA ISO
-					</a>
-				</div>
+			<div class="center-text">
+				<h3>Resources</h3>
+				<h5>The 12 step groups from the Greenbelt Step Club may optionally have their own web page listed below</h5>
+				<a href="aa.html">AA</a>
 			</div>
+			
 		</main>
 		<footer class="page-footer green darken-3">
 			<div class="container">
@@ -131,8 +69,9 @@
 		<script src="js/materialize.min.js" type="text/javascript"></script>
 
 <script type="text/javascript">
+
 //     https://learn.jquery.com/using-jquery-core/document-ready/
-$(document).ready(function () {
+$(document).ready(function(){
 	
 	//      https://materializecss.com/dropdown.html
 	M.AutoInit();


### PR DESCRIPTION
Let the groups be responsible for their own fellowship specific content. In effect, the AA " meeting resources" page is placed in an AA only page, and not lumped in with the other fellowships. 